### PR TITLE
 WildlifeCompliace: #5204 - Module-based granular permission management system.

### DIFF
--- a/wildlifecompliance/components/applications/api.py
+++ b/wildlifecompliance/components/applications/api.py
@@ -507,6 +507,11 @@ class ApplicationViewSet(viewsets.ModelViewSet):
             except EmailUser.DoesNotExist:
                 raise serializers.ValidationError(
                     'A user with the id passed in does not exist')
+
+            if not request.user.has_perm('can_assign_officers'):
+                raise serializers.ValidationError(
+                    'You are not authorized to assign assessors.')
+
             instance.assign_officer(request, user)
             serializer = InternalApplicationSerializer(
                 instance, context={'request': request})
@@ -735,6 +740,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
                 'application_fee': application_fee,
                 'licence_fee': licence_fee
             }
+
             serializer = SaveApplicationSerializer(data=data)
             serializer.is_valid(raise_exception=True)
             serializer.save()

--- a/wildlifecompliance/components/applications/models.py
+++ b/wildlifecompliance/components/applications/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 import datetime
+import logging
 from django.db import models, transaction
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -36,6 +37,8 @@ from wildlifecompliance.components.applications.email import (
 from wildlifecompliance.ordered_model import OrderedModel
 from collections import OrderedDict
 # from wildlifecompliance.components.licences.models import WildlifeLicenceActivityType,WildlifeLicenceClass
+
+logger = logging.getLogger(__name__)
 
 
 def update_application_doc_filename(instance, filename):

--- a/wildlifecompliance/components/applications/permissions.py
+++ b/wildlifecompliance/components/applications/permissions.py
@@ -1,0 +1,8 @@
+CUSTOM_GROUP_PERMISSIONS = {
+    'can_assign_officers': {
+        'name': 'Can assign officers',
+        'app_label': 'wildlifecompliance',
+        'model': 'application',
+        'default_groups': ['Wildlife Compliance Officers']
+    },
+}

--- a/wildlifecompliance/components/returns/api.py
+++ b/wildlifecompliance/components/returns/api.py
@@ -34,6 +34,9 @@ from wildlifecompliance.helpers import is_customer, is_internal
 from wildlifecompliance.utils import excel
 from wildlifecompliance.components.returns.utils import _is_post_data_valid, _get_table_rows_from_post, _create_return_data_from_post_data
 from wildlifecompliance.components.returns.utils import SpreadSheet
+from wildlifecompliance.components.licences.models import (
+    WildlifeLicence
+)
 from wildlifecompliance.components.returns.models import (
     Return,
     ReturnUserAction,

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/common/licences_dashboard.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/common/licences_dashboard.vue
@@ -102,6 +102,10 @@ export default {
             licence_activityTitles : [],
             licence_regions: [],
             licence_submitters: [],
+            licence_licenceTypes: [],
+            licence_status: [],
+            licence_categories: [],
+            licence_categoryStatus: [],
             licence_headers:["Number","Licence Type","Licence Holder","Status","Issue Date","Licence","Action"],
             licence_options:{
                 language: {

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/common/returns_dashboard.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/common/returns_dashboard.vue
@@ -102,6 +102,7 @@ export default {
             application_activityTitles : [],
             application_regions: [],
             application_submitters: [],
+            return_licence_types: [],
             application_headers:["Number","Due Date","Status","Licence","Action"],
             application_options:{
                 language: {

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/external/application_apply.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/external/application_apply.vue
@@ -77,6 +77,9 @@ export default {
     isLoading: function() {
       return this.loading.length > 0
     },
+    hasOrgs: function() {
+        return this.profile.wildlifecompliance_organisations && this.profile.wildlifecompliance_organisations.length > 0 ? true: false;
+    },
     org: function() {
         let vm = this;
         if (vm.behalf_of != '' || vm.behalf_of != 'other'){

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/user/profile.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/user/profile.vue
@@ -294,7 +294,7 @@
                                         </span>
                                         <span  style="margin-left:10px;margin-top:10px;">{{uploadedFileName}}</span>
                                     </label>
-                                    </br>
+                                    <br/>
 
                                     <label for="" class="col-sm-10 control-label" style="text-align:left;">You will be notified by email once the Department has checked the organisation details.
                                     </label>
@@ -329,8 +329,8 @@
                               </div>
                               <div class="form-group" v-if="newOrg.exists && newOrg.detailsChecked">
                                   <label class="col-sm-12" style="text-align:left;margin-bottom:20px;">
-                                    This organisation has already been registered with the system. Please enter the two pin codes below.</br>
-                                    These pin codes can be retrieved from one of the following people:</br> {{newOrg.first_five}}
+                                    This organisation has already been registered with the system. Please enter the two pin codes below.<br/>
+                                    These pin codes can be retrieved from one of the following people:<br/> {{newOrg.first_five}}
                                   </label>
                                   <label for="" class="col-sm-2 control-label" >Pin 1</label>
                                   <div class="col-sm-2">
@@ -347,7 +347,7 @@
                               </div>
                               <div class="form-group" v-else-if="!newOrg.exists && newOrg.detailsChecked">
                                   <label class="col-sm-12" style="text-align:left;">
-                                    This organisation has not yet been registered with this system. Please upload a letter on organisation head stating that you are an employee of this organisation.</br>
+                                    This organisation has not yet been registered with this system. Please upload a letter on organisation head stating that you are an employee of this organisation.<br/>
                                   </label>
                                   <div class="col-sm-12">
                                     <span class="btn btn-info btn-file pull-left">
@@ -363,7 +363,7 @@
                               </div>
                               <div class="form-group" v-else-if="newOrg.exists && !newOrg.detailsChecked">
                                   <label class="col-sm-12" style="text-align:left;">
-                                    Please upload a letter on organisation head stating that you are an employee of this organisation.</br>
+                                    Please upload a letter on organisation head stating that you are an employee of this organisation.<br/>
                                   </label>
                                   <div class="col-sm-12">
                                     <span class="btn btn-info btn-file pull-left">

--- a/wildlifecompliance/management/permissions_manager.py
+++ b/wildlifecompliance/management/permissions_manager.py
@@ -1,0 +1,104 @@
+import importlib
+import logging
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth.models import Group, ContentType, Permission
+
+
+logger = logging.getLogger(__name__)
+
+
+class PermissionCollector(object):
+
+    MODULE_NAME = 'permissions'
+
+    @classmethod
+    def iter_app_configs(cls):
+        for app in settings.INSTALLED_APPS:
+            try:
+                module = importlib.import_module('%s.%s' % (app, cls.MODULE_NAME))
+            except ImportError:
+                continue
+
+            yield app, module
+
+    @classmethod
+    def default_permissions(cls):
+        """
+        Collects up all of the custom permission configurations from the app_dir/permissions.py
+        modules for each app in INSTALLED_APPS and returns a dictionary of the
+        form:
+            permission_name: {permission_spec}
+        """
+        permissions = {}
+
+        for app, module in cls.iter_app_configs():
+            module_permissions = getattr(module, cls.PERMISSION_KEY, {})
+
+            if module_permissions:
+                # Detect duplicate permissions
+                for permission_name in module_permissions:
+                    if permission_name in permissions:
+                        raise RuntimeError('Two permissions created with the ' +
+                                           'same name: {}'.format(permission_name))
+                permissions.update(module_permissions)
+
+        return permissions
+
+
+class CustomPermissionCollector(PermissionCollector):
+
+    PERMISSION_KEY = 'CUSTOM_GROUP_PERMISSIONS'
+
+    def get_or_create_models(self):
+        """
+        A mapping of permission name to permission instance. If the permission does not exist, it is created.
+        """
+        default_permissions = self.default_permissions()
+        actual = {}
+
+        for permission_name, config in default_permissions.items():
+
+            try:
+                content_type = ContentType.objects.get(
+                    model=config['model'],
+                    app_label=config['app_label'],
+                )
+            except ObjectDoesNotExist:
+                logger.error("Content Type {app_label} - {model} not found for permission: {codename}".format(
+                    app_label=config['app_label'],
+                    model=config['model'],
+                    codename=permission_name,
+                ))
+                continue
+
+            permission, created = Permission.objects.get_or_create(
+                name=config['name'],
+                content_type_id=content_type.id,
+                codename=permission_name
+            )
+            if created:
+                logger.info("Created custom permission: %s" % (permission_name))
+
+            # Only assign permissions to default groups if they didn't exist in the database before.
+            # Don't re-add permissions that were revoked by admins manually!
+            if 'default_groups' in config and created:
+                for group_name in config['default_groups']:
+                    try:
+                        group = Group.objects.get(name=group_name)
+                    except ObjectDoesNotExist:
+                        logger.error("Cannot assign permission {permission_name} to a non-existent group: {group}".format(
+                            permission_name=permission_name,
+                            group=group_name
+                        ))
+                        continue
+
+                    group.permissions.add(permission)
+                    logger.info("Assigned permission {permission_name} to group: {group}".format(
+                        permission_name=permission_name,
+                        group=group_name
+                    ))
+
+            actual[permission_name] = permission
+
+        return actual

--- a/wildlifecompliance/urls.py
+++ b/wildlifecompliance/urls.py
@@ -1,3 +1,4 @@
+import logging
 from django.conf import settings
 from django.conf.urls import url, include
 from django.views.generic.base import TemplateView, RedirectView
@@ -14,8 +15,12 @@ from wildlifecompliance.components.organisations import api as org_api
 from wildlifecompliance.components.applications import api as application_api
 from wildlifecompliance.components.licences import api as licence_api
 from wildlifecompliance.components.returns import api as return_api
+from wildlifecompliance.management.permissions_manager import CustomPermissionCollector
+from wildlifecompliance.utils import are_migrations_running
 
 from ledger.urls import urlpatterns as ledger_patterns
+
+logger = logging.getLogger(__name__)
 
 # API patterns
 router = routers.DefaultRouter()
@@ -112,6 +117,12 @@ urlpatterns = [
         name='mgt-commands'),
 
 ] + ledger_patterns
+
+if not are_migrations_running():
+    logger.info("Verifying presence of custom group permissions in the database...")
+    permission_collector = CustomPermissionCollector()
+    permission_collector.get_or_create_models()
+    logger.info("Finished collecting custom permissions.")
 
 if settings.DEBUG:  # Serve media locally in development.
     urlpatterns += static(settings.MEDIA_URL,

--- a/wildlifecompliance/utils/__init__.py
+++ b/wildlifecompliance/utils/__init__.py
@@ -1,8 +1,6 @@
-from django.conf import settings
+import sys
 from collections import OrderedDict
-from wildlifecompliance.components.applications.models import Application
 from wildlifecompliance.components.licences.models import DefaultActivity
-#from copy import deepcopy
 
 
 class ActivityPurposeMap():
@@ -215,6 +213,8 @@ def search_keys(dictionary, search_list=['help_text', 'label']):
     return help_list
 
 
+"""
+# Commented out as Proposal is not imported and undefined.
 def test_search_multiple_keys():
     p = Proposal.objects.get(id=139)
     return search_multiple_keys(
@@ -223,6 +223,7 @@ def test_search_multiple_keys():
         search_list=[
             'label',
             'name'])
+"""
 
 
 def search_multiple_keys(
@@ -316,3 +317,10 @@ def flatten(old_data, new_data=None, parent_key='', delimiter='.', width=4):
             raise AttributeError("key {} is already used".format(parent_key))
 
     return new_data
+
+
+def are_migrations_running():
+    '''
+    Checks whether the app was launched with the migration-specific params
+    '''
+    return sys.argv and ('migrate' in sys.argv or 'makemigrations' in sys.argv)


### PR DESCRIPTION
Step 1: create a **permissions.py** file within the relevant module (e.g. **wildlifecompliance/applications/permissions.py**) with the specification of custom permissions.
The format is as follows:
```
CUSTOM_GROUP_PERMISSIONS = {
    'can_assign_officers': {
        'name': 'Can assign officers',
        'app_label': 'wildlifecompliance',
        'model': 'application',
        'default_groups': ['Wildlife Compliance Officers']
    },
}
```
(**default_groups** field is optional)

Step 2: Use the new permission as you would use the regular Django group permissions:
```
if not request.user.has_perm('can_assign_officers'):
    raise serializers.ValidationError(
        'You are not authorized to assign assessors.')
```

The new permissions are added to the database automatically (upon launching or rebooting the web server), no need to run migrations.
These will also appear and will be manageable in the default "Authentication and Authorization › Groups" Django admin interface.

Please note: custom permissions are automatically assigned to the groups (listed in **default_groups**) only once. You can safely revoke these permissions from a group later knowing that these will not be re-added upon reboot.